### PR TITLE
Adds --head on HEAD requests

### DIFF
--- a/cURLCodeGenerator.coffee
+++ b/cURLCodeGenerator.coffee
@@ -129,6 +129,7 @@ cURLCodeGenerator = ->
     @generateRequest = (request) ->
         view =
             "request": request
+            "request_is_head": request.method == "HEAD"
             "headers": @headers request
             "body": @body request
 

--- a/cURLCodeGenerator.coffee
+++ b/cURLCodeGenerator.coffee
@@ -130,6 +130,7 @@ cURLCodeGenerator = ->
         view =
             "request": request
             "request_is_head": request.method == "HEAD"
+            "specify_method": request.method != "GET" && request.method != "HEAD"
             "headers": @headers request
             "body": @body request
 

--- a/curl.mustache
+++ b/curl.mustache
@@ -1,7 +1,7 @@
 {{#request.name}}## {{{request.name}}}
 {{/request.name}}{{#request.cURLDescription}}
 {{{request.cURLDescription}}}
-{{/request.cURLDescription}}curl -X "{{{request.method}}}" "{{{request.url}}}" \
+{{/request.cURLDescription}}curl {{#request_is_head}}--head {{/request_is_head}}-X "{{{request.method}}}" "{{{request.url}}}" \
      {{#headers.has_headers}}
      {{#headers.header_list}}
      -H "{{{header_name}}}: {{{header_value}}}" \

--- a/curl.mustache
+++ b/curl.mustache
@@ -1,7 +1,7 @@
 {{#request.name}}## {{{request.name}}}
 {{/request.name}}{{#request.cURLDescription}}
 {{{request.cURLDescription}}}
-{{/request.cURLDescription}}curl {{#request_is_head}}--head {{/request_is_head}}-X "{{{request.method}}}" "{{{request.url}}}" \
+{{/request.cURLDescription}}curl {{#request_is_head}}--head {{/request_is_head}}{{#specify_method}}-X "{{{request.method}}}" {{/specify_method}}"{{{request.url}}}" \
      {{#headers.has_headers}}
      {{#headers.header_list}}
      -H "{{{header_name}}}: {{{header_value}}}" \


### PR DESCRIPTION
The currently generated cURL requests for HEAD do not work.  It throws warnings as follows and never completes.

![screen shot 2017-02-20 at 10 57 21 am](https://cloud.githubusercontent.com/assets/133747/23134705/6523ba68-f75b-11e6-9917-c128e79f33d6.png)

This adds --head on HEAD requests to correct the issue:

![screen shot 2017-02-20 at 10 57 35 am](https://cloud.githubusercontent.com/assets/133747/23134747/8a2ba49c-f75b-11e6-8e09-663597cc454a.png)
