### PR TITLE
Fix unescaped password

### DIFF
--- a/cURLCodeGenerator.coffee
+++ b/cURLCodeGenerator.coffee
@@ -6,7 +6,7 @@ addslashes = (str) ->
     ("#{str}").replace(/[\\"]/g, '\\$&')
 
 addslashes_single_quotes = (str) ->
-    ("#{str}").replace(/[\\']/g, '\\$&')
+    ("#{str}").replace(/\\/g, '\\$&').replace(/'/g, "'\"'\"'")
 
 cURLCodeGenerator = ->
     self = this

--- a/cURLCodeGenerator.coffee
+++ b/cURLCodeGenerator.coffee
@@ -42,8 +42,8 @@ cURLCodeGenerator = ->
             userpass = decoded.match(/([^:]*):?(.*)/)
 
             return {
-                "username": userpass[1] || '',
-                "password": userpass[2] || ''
+                "username": addslashes_single_quotes(userpass[1]) || '',
+                "password": addslashes_single_quotes(userpass[2]) || ''
             }
 
         digestDS = request.getHeaderByName('Authorization', true)
@@ -64,8 +64,8 @@ cURLCodeGenerator = ->
 
             return {
                 "isDigest": true,
-                "username": username,
-                "password": password
+                "username": addslashes_single_quotes(username),
+                "password": addslashes_single_quotes(password)
             }
 
         return null

--- a/curl.mustache
+++ b/curl.mustache
@@ -8,7 +8,7 @@
      {{/headers.header_list}}
      {{/headers.has_headers}}
      {{#headers.auth}}
-     -u {{{headers.auth.username}}}:{{{headers.auth.password}}} {{#headers.auth.isDigest}}--digest{{/headers.auth.isDigest}}\
+     -u '{{{headers.auth.username}}}:{{{headers.auth.password}}}' {{#headers.auth.isDigest}}--digest{{/headers.auth.isDigest}}\
      {{/headers.auth}}
      {{! ----- }}
      {{#body.has_url_encoded_body}}


### PR DESCRIPTION
Right now if my basic auth password contains anything bash processes, namely quotes, backtick `$` or `!` - there's probably more as well it's not properly quoted/escaped, causing problems.

This pull request wraps the username and password in single quotes, as well as correcting the single quote escaper.

The existing single quote escaper would replace `\` with `\\` and `'` with `\'` 

The latter single quote escape is incorrect. This can be seen by trying `echo 'a\'b'` at the command line - doesn't work. The correct way is the somewhat gross `'"'"'` which leaves the current string, opens a double quoted string, uses single quote, closes the double quoted string, opens a new single quoted string.  It's gross, but it works.

Compare:

![image](https://user-images.githubusercontent.com/133747/27045308-1534dc04-4f66-11e7-8184-e5a54f5c8493.png)
