### PR TITLE
Fix issue where single quote were escaped incorrectly

### DIFF
--- a/cURLCodeGenerator.coffee
+++ b/cURLCodeGenerator.coffee
@@ -6,7 +6,7 @@ addslashes = (str) ->
     ("#{str}").replace(/[\\"]/g, '\\$&')
 
 addslashes_single_quotes = (str) ->
-    ("#{str}").replace(/\\/g, '\\$&').replace(/'/g, "'\"'\"'")
+    ("#{str}").replace(/\\/g, '\\$&').replace(/'/g, "\\'")
 
 cURLCodeGenerator = ->
     self = this


### PR DESCRIPTION
I'm not sure about the reason (and all cases) for escaping single quote before my change, but according to [this](https://tldp.org/LDP/Bash-Beginners-Guide/html/sect_03_03.html), is enough to use single `\` for escaping.

I couldn't find a case where my fix does not work. 

Also, it would be nice to have support for other shells like `fish` :). In this case removing `$` from `-d` parameter helps.

[Link to the issue](https://www.notion.so/rapidapi/cURL-export-extension-improperly-converts-character-81daf4dc5970489481ba3bd17671d5b6)